### PR TITLE
Add capability of specifying JWT decode algorithm

### DIFF
--- a/lib/fido_metadata/client.rb
+++ b/lib/fido_metadata/client.rb
@@ -23,9 +23,9 @@ module FidoMetadata
       File.read(File.join(__dir__, "..", "Root.cer"))
     )].freeze
 
-    def download_toc(uri, trusted_certs: FIDO_ROOT_CERTIFICATES)
+    def download_toc(uri, algorithms: ["RS256"], trusted_certs: FIDO_ROOT_CERTIFICATES)
       response = get(uri)
-      payload, _ = JWT.decode(response, nil, true, algorithms: ["RS256"]) do |headers|
+      payload, _ = JWT.decode(response, nil, true, algorithms: algorithms) do |headers|
         jwt_certificates = headers["x5c"].map do |encoded|
           OpenSSL::X509::Certificate.new(Base64.strict_decode64(encoded))
         end


### PR DESCRIPTION
## Summary

This PR allow users of the gem to be able to specify the JWT decode algorithm when downloading a TOC. I let the default be `RS256` which is the one that the MSD3 BLOB uses but I'm open to change it. 

The reason behind this change is that users might have to download TOC from other endpoints different than the MSD3 BLOB which neeed to be decoded with a different algorithm:

```
~/.gem/ruby/3.2.2/gems/jwt-2.2.1/lib/jwt/decode.rb:40:in `verify_signature': Expected a different algorithm (JWT::IncorrectAlgorithm)
	from ~/.gem/ruby/3.2.2/gems/jwt-2.2.1/lib/jwt/decode.rb:26:in `decode_segments'
	from ~/.gem/ruby/3.2.2/gems/jwt-2.2.1/lib/jwt.rb:28:in `decode'
	from ~/.gem/ruby/3.2.2/fido_metadata/lib/fido_metadata/client.rb:28:in `download_toc'
```