### PR TITLE
Follow redirects when the response is 302

### DIFF
--- a/lib/fido_metadata/client.rb
+++ b/lib/fido_metadata/client.rb
@@ -47,6 +47,10 @@ module FidoMetadata
       response = http(uri).request(get)
       response.value
       response.body
+    rescue Net::HTTPRetriableError => e
+      if e.response.is_a? Net::HTTPResponse
+        get(URI(e.response["location"]))
+      end
     end
 
     def http(uri)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -156,5 +156,20 @@ RSpec.describe FidoMetadata::Client do
         expect { subject }.to raise_error(described_class::UnverifiedSigningKeyError, error)
       end
     end
+
+    context "when a CRL url redirects to another url" do
+      let(:redirecting_url) do
+        { status: 302, headers: { location: "http://crl.globalsign.com/gs/redirected.crl" } }
+      end
+
+      before(:each) do
+        stub_request(:get, "http://crl.globalsign.com/gs/gsextendvalsha2g3r3.crl").to_return(redirecting_url)
+        stub_request(:get, "http://crl.globalsign.com/gs/redirected.crl").to_return(extendval_crl)
+      end
+
+      specify do
+        expect(subject).to include("nextUpdate", "entries", "no")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Currently when downloading CRLs for some certificates, we run into urls that return a 302. This commit should add the code to follow the redirect if we run in those cases.